### PR TITLE
Fix: invalid region return if size is unchanged

### DIFF
--- a/svgtoicons.rb
+++ b/svgtoicons.rb
@@ -59,7 +59,7 @@ def aspect_fit(width, height, original_width, original_height)
 	width = width.to_f
 	height = height.to_f
 	if width == original_width && height == original_height
-		return {x0: 0, y0: 0, x1: height, y1: width}
+		return {x0: 0, y0: 0, x1: width, y1: height}
 	end
 	orig_aspect_ratio = original_width / original_height
 	req_aspect_ratio = width / height

--- a/svgtoicons.rb
+++ b/svgtoicons.rb
@@ -59,7 +59,7 @@ def aspect_fit(width, height, original_width, original_height)
 	width = width.to_f
 	height = height.to_f
 	if width == original_width && height == original_height
-		return {x0: 0, y0: 0, x1: height, x2: width}
+		return {x0: 0, y0: 0, x1: height, y1: width}
 	end
 	orig_aspect_ratio = original_width / original_height
 	req_aspect_ratio = width / height


### PR DESCRIPTION
When the requested size (width and height) was identical to the original size, an invalid region was returned by aspect_fit (typo in the structure).